### PR TITLE
Conda - iSnobal env - Add required GDAL dependencies

### DIFF
--- a/conda/isnobal.yaml
+++ b/conda/isnobal.yaml
@@ -9,6 +9,8 @@ dependencies:
 - cython
 - dateparser=0.7.2
 - gdal=3.11
+- libgdal-grib
+- libgdal-netcdf
 - make
 - netCDF4
 - numpy<1.23
@@ -23,7 +25,6 @@ dependencies:
 - siphon
 - utm==0.5
 - xarray<2023
-- pip
 - pip:
     - inicheck
     - spatialnc


### PR DESCRIPTION
Add needed packages to support SMRF reading Grib files via GDAL.

Ref: https://github.com/iSnobal/smrf/pull/22