### PR TITLE
Conda - iSnobal - Pin GDAL plugins to same version

### DIFF
--- a/conda/isnobal.yaml
+++ b/conda/isnobal.yaml
@@ -9,8 +9,8 @@ dependencies:
 - cython
 - dateparser=0.7.2
 - gdal=3.11
-- libgdal-grib
-- libgdal-netcdf
+- libgdal-grib=3.11
+- libgdal-netcdf=3.11
 - make
 - netCDF4
 - numpy<1.23


### PR DESCRIPTION
Had some resolution issues where GDAL was installed with 3.11, but the plugin for NetCDF was installed with 3.10. Pinning now both needed plugins to the same as the main library.

This makes the tests pass again for SMRF on a local fresh install.

Sample output from a GitHub action:
```
    + libgdal-core              3.11.3  h14edee0_6              conda-forge      12MB
    + libgdal-grib              3.11.3  hb20eef8_6              conda-forge     731kB
    + libgdal-hdf4              3.10.0  hbbee16a_4              conda-forge     580kB
    + libgdal-hdf5              3.10.0  hd75530a_4              conda-forge     646kB
    + libgdal-netcdf            3.10.0  h2b12c9b_4              conda-forge     739kB
```