### PR TITLE
HRRR download - Add Shortwave direct and diffuse variables

### DIFF
--- a/scripts/HRRR/copy_1st_hour.sh
+++ b/scripts/HRRR/copy_1st_hour.sh
@@ -5,19 +5,25 @@
 #   copy_1st_hour.sh hrrr.t09z.wrfsfcf02.grib2 hrrr.t10z.wrfsfcf01.grib2
 #
 
+set -e 
+
 SOURCE_FILE=$1
 CREATED_FILE=$2
 CREATED_HOUR=1
 
 # Adjust datetime stamp and forecast time
-wgrib2 -set_date +1hr -set_ftime "${CREATED_HOUR} hour fcst" ${SOURCE_FILE} -grib ${CREATED_FILE}
+wgrib2 ${SOURCE_FILE} \
+  -set_date +1hr \
+  -set_ftime "${CREATED_HOUR} hour fcst" \
+  -grib_out ${CREATED_FILE}
 
 # Print to verify output
 echo " ** Result **"
-wgrib2 -s ${CREATED_FILE}
+wgrib2 -v2 ${CREATED_FILE}
 
 # Clean up missing file
 find . -type f -name "${CREATED_FILE}.missing" -size 0 -delete
 
 # Remove SOURCE_FILE
 rm ${SOURCE_FILE}
+

--- a/scripts/HRRR/copy_1st_hour.sh
+++ b/scripts/HRRR/copy_1st_hour.sh
@@ -5,14 +5,18 @@
 #   copy_1st_hour.sh hrrr.t09z.wrfsfcf02.grib2 hrrr.t10z.wrfsfcf01.grib2
 #
 
-set -e 
+set -e
 
 SOURCE_FILE=$1
 CREATED_FILE=$2
+
+# Below should match the variables in the HRRR file, except for precipitation
+HRRR_VARIABLES="HGT|TMP|RH|UGRD|VGRD|TCDC|DSWRF|VBDSF|VDDSF|DLWRF|APCP:surface:1-2 hour"
 CREATED_HOUR=1
 
 # Adjust datetime stamp and forecast time
 wgrib2 ${SOURCE_FILE} \
+  -match "${HRRR_VARIABLES}" \
   -set_date +1hr \
   -set_ftime "${CREATED_HOUR} hour fcst" \
   -grib_out ${CREATED_FILE}

--- a/scripts/HRRR/copy_6th_hour.sh
+++ b/scripts/HRRR/copy_6th_hour.sh
@@ -5,6 +5,8 @@
 #   copy_6th_hour.sh hrrr.t09z.wrfsfcf07.grib2 hrrr.t10z.wrfsfcf06.grib2
 #
 
+set -e
+
 # User input
 SOURCE_FILE=$1
 CREATED_FILE=$2
@@ -14,15 +16,17 @@ HRRR_VARIABLES="HGT|TMP|RH|UGRD|VGRD|TCDC|DSWRF|VBDSF|VDDSF|DLWRF"
 CREATED_HOUR=6
 
 # Grab non-precip fields
-wgrib2 -match ${HRRR_VARIABLES} \
+wgrib2 ${SOURCE_FILE} \
+  -match ${HRRR_VARIABLES} \
   -set_date +1hr \
-  -set_ftime "${CREATED_HOUR} hour fcst" ${SOURCE_FILE} \
-  -grib ${CREATED_FILE}_1
+  -set_ftime "${CREATED_HOUR} hour fcst" \
+  -grib_out ${CREATED_FILE}_1
 # Instant precip for hour
-wgrib2 -match "APCP:surface:${CREATED_HOUR}-7 hour acc fcst" \
+wgrib2 ${SOURCE_FILE} \
+  -match "APCP:surface:${CREATED_HOUR}-7 hour acc fcst" \
   -set_date +1hr \
-  -set_ftime "5-${CREATED_HOUR} hour acc fcst" ${SOURCE_FILE} \
-  -grib ${CREATED_FILE}_2
+  -set_ftime "5-${CREATED_HOUR} hour acc fcst" \
+  -grib_out ${CREATED_FILE}_2
 
 # Concatenate
 cat ${CREATED_FILE}_{1,2} > ${CREATED_FILE}
@@ -32,10 +36,11 @@ rm ${CREATED_FILE}_{1,2}
 
 # Print to verify output
 echo " ** Result **"
-wgrib2 -s ${CREATED_FILE}
+wgrib2 -v2 ${CREATED_FILE}
 
 # Clean up missing file
 find . -type f -name "${CREATED_FILE}.missing" -size 0 -delete
 
 # Remove SOURCE_FILE
 rm ${SOURCE_FILE}
+

--- a/scripts/HRRR/copy_6th_hour.sh
+++ b/scripts/HRRR/copy_6th_hour.sh
@@ -5,14 +5,24 @@
 #   copy_6th_hour.sh hrrr.t09z.wrfsfcf07.grib2 hrrr.t10z.wrfsfcf06.grib2
 #
 
+# User input
 SOURCE_FILE=$1
 CREATED_FILE=$2
+
+# Below should match the variables in the HRRR file, except for precipitation
+HRRR_VARIABLES="HGT|TMP|RH|UGRD|VGRD|TCDC|DSWRF|VBDSF|VDDSF|DLWRF"
 CREATED_HOUR=6
 
 # Grab non-precip fields
-wgrib2 -match "HGT|TMP|RH|UGRD|VGRD|TCDC|DSWRF" -set_date +1hr -set_ftime "${CREATED_HOUR} hour fcst" ${SOURCE_FILE} -grib ${CREATED_FILE}_1
+wgrib2 -match ${HRRR_VARIABLES} \
+  -set_date +1hr \
+  -set_ftime "${CREATED_HOUR} hour fcst" ${SOURCE_FILE} \
+  -grib ${CREATED_FILE}_1
 # Instant precip for hour
-wgrib2 -match "APCP:surface:${CREATED_HOUR}" -set_date +1hr -set_ftime "5-${CREATED_HOUR} hour acc fcst" ${SOURCE_FILE} -grib ${CREATED_FILE}_2
+wgrib2 -match "APCP:surface:${CREATED_HOUR}-7 hour acc fcst" \
+  -set_date +1hr \
+  -set_ftime "5-${CREATED_HOUR} hour acc fcst" ${SOURCE_FILE} \
+  -grib ${CREATED_FILE}_2
 
 # Concatenate
 cat ${CREATED_FILE}_{1,2} > ${CREATED_FILE}

--- a/scripts/HRRR/download_hrrr.sh
+++ b/scripts/HRRR/download_hrrr.sh
@@ -18,7 +18,7 @@
 #
 set -e
 
-export HRRR_VARS='TMP:2 m|RH:2 m|DPT: 2 m|UGRD:10 m|VGRD:10 m|TCDC:|APCP:surface|DSWRF:surface|DLWRF:surface|HGT:surface'
+export HRRR_VARS='TMP:2 m|RH:2 m|DPT: 2 m|UGRD:10 m|VGRD:10 m|TCDC:|APCP:surface|DSWRF:surface|DLWRF:surface|VBDSF:surface|VDDSF:surface|HGT:surface'
 export HRRR_FC_HOURS=(1 6)
 export HRRR_DAY_HOURS=$(seq 0 23)
 


### PR DESCRIPTION
Transferring the PR that was open with isnoda to add the diffuse and direct HRRR shortwave variables. Also improved the readability for the helper scripts to get to missing HRRR data.