### PR TITLE
Config - AWSM - Remove thread options from .ini

### DIFF
--- a/config/awsm.ini
+++ b/config/awsm.ini
@@ -218,8 +218,6 @@ mask_output:      False
 ################################################################################
 
 [system]
-threading:         False
-time_out:          None
 qotw:              True
 
 


### PR DESCRIPTION
This has been removed from SMRF: https://github.com/iSnobal/smrf/pull/23