### PR TITLE
Conda - Katana - Remove pin from WindNinja

### DIFF
--- a/conda/katana.yaml
+++ b/conda/katana.yaml
@@ -11,7 +11,7 @@ dependencies:
   - pytz
   - regex=2021
   - wgrib2
-  - windninja==3.11.2
+  - windninja
   - pip:
     - coloredlogs==15.0.1
     - git+https://github.com/iSnobal/katana.git@20250822


### PR DESCRIPTION
Remove the version restriction for WindNinja so we use the latest version of the conda package that has parallelization.