### PR TITLE
Release - 20251208 - Includes AWSM, SMRF, Pysnobal

### DIFF
--- a/conda/isnobal.yaml
+++ b/conda/isnobal.yaml
@@ -28,4 +28,4 @@ dependencies:
 - pip:
     - inicheck
     - spatialnc
-    - git+https://github.com/iSnobal/awsm.git@20250722
+    - git+https://github.com/iSnobal/awsm.git@20251208


### PR DESCRIPTION
Make Toposplit part of the installed version via conda.
