### PR TITLE
Config - AWSM - Update sample precip section to essentials

### DIFF
--- a/config/awsm.ini
+++ b/config/awsm.ini
@@ -100,22 +100,16 @@ reduction_factor:     1.0
 
 [precip]
 distribution:                  grid
-grid_local:                    True
 grid_method:                   cubic
-grid_mask:                     True
-grid_local_n:                  25
+grid_mask:                     False
 detrend:                       False
-detrend_slope:                 1
 min:                           0.0
 max:                           None
 precip_temp_method:            wet_bulb
 precip_rescaling_model:        None
-marks2017_timesteps_to_end_storms: 6
-susong1999_timesteps_to_end_storms: 6
-new_snow_density_model:        susong1999
-winstral_veg_3011:             0.7
-station_adjust_for_undercatch: False
 storm_mass_threshold:          1.0
+new_snow_density_model:        susong1999
+susong1999_timesteps_to_end_storms: 6
 
 
 ################################################################################


### PR DESCRIPTION
This updates the `grid_mask` to False as the feature to mask out HRRR areas via topo mask is not used (or tested). The intent is to prevent some unexpected behavior in case a topo mask is added and the feature not intentionally requested.

Overall the `[precip]` section now sets the required values all HRRR-iSnobal setups have been using and removes any defaults that are not applied or needed. It does repeat some default values, which is intentional to make the user aware.

## Background
In my exploration to better understand how precip is distributed, I discovered the the `grid_mask` was set to `True` although we don't use the feature. This triggered a logic in section that was not expensive to execute, but unnecessary.
https://github.com/iSnobal/smrf/blob/bb8e590644113bb664735d3d57da581cf99185db/smrf/spatial/grid.py#L92-L104

Of further note is that this template also does not apply elevational detrending of precipitation and simply does "cubic" as per scipy implementation.
